### PR TITLE
Add mac-install-rbenv to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ your own applications to install
 ```
 ./mac-install-dev-apps -a "docker visual-studio-code"
 ```
+
+#### Homebrew Install `rbenv`
+Homebrew install `rbenv` and add its initialization
+to your `.zshrc` file
+```
+./mac-install-rbenv
+```


### PR DESCRIPTION
Add documentation on using new `mac-install-rbenv` script to `README`.

- [x] Vetted by manual inspection on branch